### PR TITLE
Add simple GitHub-style profile front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # sirmonrad.github.io
+
 Personal Profile
+
+This repository hosts a simple GitHub-style profile front page. Open `index.html` in your browser to view a mock GitHub profile layout with an avatar, bio, and sample repositories.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Sirmonrad - GitHub Profile</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      background-color: #f6f8fa;
+      margin: 0;
+    }
+    header {
+      background-color: #24292e;
+      color: white;
+      padding: 10px 20px;
+      display: flex;
+      align-items: center;
+    }
+    header .logo {
+      font-weight: bold;
+      font-size: 20px;
+      margin-right: 20px;
+    }
+    main {
+      max-width: 980px;
+      margin: 20px auto;
+      display: flex;
+    }
+    .profile {
+      width: 25%;
+      padding-right: 20px;
+    }
+    .avatar {
+      width: 100%;
+      border-radius: 50%;
+    }
+    .profile h1 {
+      font-size: 26px;
+      margin: 10px 0 5px;
+    }
+    .profile p {
+      margin: 0 0 10px;
+      color: #57606a;
+    }
+    .profile .meta span {
+      display: block;
+      margin: 4px 0;
+    }
+    .repos {
+      width: 75%;
+    }
+    .repo-card {
+      background: white;
+      border: 1px solid #d0d7de;
+      border-radius: 6px;
+      padding: 16px;
+      margin-bottom: 16px;
+    }
+    .repo-card h3 {
+      margin: 0 0 8px;
+      font-size: 20px;
+    }
+    .repo-card p {
+      margin: 0 0 8px;
+      color: #57606a;
+    }
+    .repo-card .meta {
+      font-size: 12px;
+      color: #57606a;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="logo">GitHub</div>
+  </header>
+  <main>
+    <section class="profile">
+      <img class="avatar" src="https://avatars.githubusercontent.com/u/1?v=4" alt="avatar">
+      <h1>Sirmonrad</h1>
+      <p>Full Stack Developer</p>
+      <div class="meta">
+        <span>@sirmonrad</span>
+        <span>Location: Earth</span>
+      </div>
+    </section>
+    <section class="repos">
+      <div class="repo-card">
+        <h3><a href="#">awesome-project</a></h3>
+        <p>Short description of project.</p>
+        <div class="meta">HTML • Updated May 2024</div>
+      </div>
+      <div class="repo-card">
+        <h3><a href="#">another-repo</a></h3>
+        <p>Another project description.</p>
+        <div class="meta">JavaScript • Updated Apr 2024</div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `index.html` with basic GitHub-like profile layout
- document new profile page in README

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1aa74a7ac8328ad58af9daf18a3a6